### PR TITLE
Implement Vulkan-like CPU Rendering Pipeline and Reflectiveness

### DIFF
--- a/RayTracingRenderer/imgui.ini
+++ b/RayTracingRenderer/imgui.ini
@@ -1,6 +1,6 @@
 [Window][DockSpace Demo]
 Pos=0,0
-Size=1600,932
+Size=1600,900
 Collapsed=0
 
 [Window][Debug##Default]
@@ -19,27 +19,27 @@ Size=550,680
 Collapsed=0
 
 [Window][Settings]
-Pos=1298,292
-Size=302,640
+Pos=1257,793
+Size=343,107
 Collapsed=0
 DockId=0x00000004,0
 
 [Window][Viewport]
 Pos=0,26
-Size=1296,906
+Size=1255,874
 Collapsed=0
 DockId=0x00000001,0
 
 [Window][Scene]
-Pos=1298,26
-Size=302,264
+Pos=1257,26
+Size=343,765
 Collapsed=0
 DockId=0x00000003,0
 
 [Docking][Data]
-DockSpace     ID=0xF2944C7F Window=0x4647B76E Pos=138,155 Size=1600,906 Split=X
-  DockNode    ID=0x00000001 Parent=0xF2944C7F SizeRef=794,874 CentralNode=1 Selected=0x13926F0B
-  DockNode    ID=0x00000002 Parent=0xF2944C7F SizeRef=302,874 Split=Y Selected=0x54723243
-    DockNode  ID=0x00000003 Parent=0x00000002 SizeRef=302,264 Selected=0xE192E354
-    DockNode  ID=0x00000004 Parent=0x00000002 SizeRef=302,640 Selected=0x54723243
+DockSpace     ID=0xF2944C7F Window=0x4647B76E Pos=-1857,68 Size=1600,874 Split=X
+  DockNode    ID=0x00000001 Parent=0xF2944C7F SizeRef=1255,874 CentralNode=1 Selected=0x13926F0B
+  DockNode    ID=0x00000002 Parent=0xF2944C7F SizeRef=343,874 Split=Y Selected=0x54723243
+    DockNode  ID=0x00000003 Parent=0x00000002 SizeRef=302,765 Selected=0xE192E354
+    DockNode  ID=0x00000004 Parent=0x00000002 SizeRef=302,107 Selected=0x54723243
 

--- a/RayTracingRenderer/src/Camera.cpp
+++ b/RayTracingRenderer/src/Camera.cpp
@@ -12,7 +12,7 @@ Camera::Camera(float verticalFOV, float nearClip, float farClip)
 	: m_VerticalFOV(verticalFOV), m_NearClip(nearClip), m_FarClip(farClip)
 {
 	m_ForwardDirection = glm::vec3(0, 0, -1);
-	m_Position = glm::vec3(0, 0, 3);
+	m_Position = glm::vec3(0, 0, 5);
 }
 
 bool Camera::OnUpdate(float ts)

--- a/RayTracingRenderer/src/Renderer.h
+++ b/RayTracingRenderer/src/Renderer.h
@@ -18,8 +18,24 @@ public:
 
 	std::shared_ptr<Walnut::Image> GetFinalImage() const { return m_FinalImage; }
 private:
-	glm::vec4 TraceRay(const Scene& scene, const Ray& ray);
+	struct HitPayLoad
+	{
+		float Hitdistance;
+		glm::vec3 Position;
+		glm::vec3 Normal;
+		glm::vec3 Albedo;
+
+		uint32_t ObjectIndex;
+	};
+	glm::vec4 PerPixel(uint32_t x, uint32_t y); //RayGen
+	HitPayLoad TraceRay(const Ray& ray);
+	HitPayLoad ClosesRayHit(const Ray& ray, float hitDistance, int objectIndex);
+	HitPayLoad Miss(const Ray& ray);
 private:
 	std::shared_ptr<Walnut::Image> m_FinalImage;
+
+	const Camera* m_ActiveCamera = nullptr;
+	const Scene* m_ActiveScene = nullptr;
+
 	uint32_t* m_ImageData = nullptr;
 };

--- a/RayTracingRenderer/src/Scene.h
+++ b/RayTracingRenderer/src/Scene.h
@@ -3,12 +3,19 @@
 #include <glm/glm.hpp>
 #include <vector>
 
+struct Material
+{
+	glm::vec3 Albedo{ 1.0f };
+	float Roughness = 1.0f;
+	float Metallic = 0.0f;
+};
+
 struct Sphere
 {
 	glm::vec3 Position{0.0f};
 	float Radius = 0.5f;
 
-	glm::vec3 Albedo{1.0f};
+	Material Mat;
 };
 
 struct Scene

--- a/RayTracingRenderer/src/WalnutApp.cpp
+++ b/RayTracingRenderer/src/WalnutApp.cpp
@@ -20,16 +20,16 @@ public:
 			// Purple sphere in the middle
 			Sphere sphere;
 			sphere.Position = { 0.0f, 0.0f, 0.0f };
-			sphere.Radius = 0.5f;
-			sphere.Albedo = { 1.0f, 0.0f, 1.0f };
+			sphere.Radius = 1.0f;
+			sphere.Mat.Albedo = { 1.0f, 0.0f, 1.0f };
 			m_Scene.Spheres.push_back(sphere);
 		}
 		{
-			//Green sphere on the back right
+			//Blue sphere on the back right
 			Sphere sphere;
-			sphere.Position = { 1.0f, 0.0f, -1.0f };
-			sphere.Radius = 0.5f;
-			sphere.Albedo = { 0.0f, 1.0f, 0.0f };
+			sphere.Position = { 0.0f, -101.0f, -0.0f };
+			sphere.Radius = 100.0f;
+			sphere.Mat.Albedo = { 0.2f, 0.3f, 1.0f };
 			m_Scene.Spheres.push_back(sphere);
 		}
 	}
@@ -55,7 +55,9 @@ public:
 			Sphere& sphere = m_Scene.Spheres[i];
 			ImGui::DragFloat3("Position", glm::value_ptr(sphere.Position), 0.1f);
 			ImGui::DragFloat("Radious", &sphere.Radius, 0.01f);
-			ImGui::ColorEdit3("Albedo", glm::value_ptr(sphere.Albedo));
+			ImGui::ColorEdit3("Albedo", glm::value_ptr(sphere.Mat.Albedo));
+			ImGui::DragFloat("Roughnes", &sphere.Mat.Roughness);
+			ImGui::DragFloat("Metalic", &sphere.Mat.Metallic);
 			ImGui::Separator();
 			ImGui::PopID();
 		}


### PR DESCRIPTION
- Simulated Vulkan's rendering pipeline on the CPU for a more structured rendering approach.
- Introduced reflectiveness to materials, enabling more realistic rendering of reflective surfaces.
- Laid groundwork for future implementation of physically-based rendering (PBR).

TODO:
- Add support for material roughness to further improve the realism of rendered surfaces.
- Integrate metallic properties into the rendering pipeline for PBR.